### PR TITLE
added a dead-letter exchange/queue per consumer queue

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -12,10 +12,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
       - run: npm ci
       - run: npm run test
       - uses: paambaati/codeclimate-action@v2.3.0
@@ -33,10 +33,10 @@ jobs:
       packages: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 22
           registry-url: https://npm.pkg.github.com/
           scope: '@RaviPatel'
       - run: npm ci

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ Rabbitmq.prototype = {
     }
     this.ch = await this.conn.createChannel();
     await this.ch.assertExchange(config.exchange_name, config.exchange_type || 'topic', { durable: false });
+    await this._ensure_dead_letter_queue();
     R5.out.log(`RabbitMQ connected to ${this.host}:${config.queue_name || config.exchange_name}`);
     for (const consumer of this.queue_consumers) {
       await this.bind(consumer, true);
@@ -73,7 +74,7 @@ Rabbitmq.prototype = {
 
   // eslint-disable-next-line no-unused-vars
   bind: async function (callback = async (msg, message) => {}, reconnecting = false) {
-    await this.ch.assertQueue(this.config.queue_name, { durable: true });
+    await this.ch.assertQueue(this.config.queue_name, this._queue_options());
     await this.ch.prefetch(1);
 
     R5.out.log(`RabbitMQ waiting for messages from #${this.config.queue_name}..`);
@@ -87,7 +88,7 @@ Rabbitmq.prototype = {
   },
 
   get: async function () {
-    await this.ch.assertQueue(this.config.queue_name, { durable: true });
+    await this.ch.assertQueue(this.config.queue_name, this._queue_options());
     const msg = await this.ch.get(this.config.queue_name, { noAck: false });
     let message;
     if (msg) {
@@ -98,7 +99,7 @@ Rabbitmq.prototype = {
 
   send: async function (message, options = {}) {
     let message_string = JSON.stringify(message);
-    await this.ch.assertQueue(this.config.queue_name, { durable: true });
+    await this.ch.assertQueue(this.config.queue_name, this._queue_options());
 
     const delayMs = Number(options.delayMs) || 0;
     const headers = Object.assign({}, options.headers || {});
@@ -201,6 +202,28 @@ function message_summary (message) {
 function delay (ms) {
   return new Promise((res) => setTimeout(res, ms));
 }
+
+Rabbitmq.prototype._queue_options = function () {
+  return this._dlx_name
+    ? { durable: true, arguments: { 'x-dead-letter-exchange': this._dlx_name } }
+    : { durable: true };
+};
+
+// Routes messages here after they're nacked/rejected without requeue, or expire -
+// otherwise a poison message just crash-loops the consumer pod forever (redelivered
+// on every reconnect) with no way to inspect or discard it. No queue_name means this
+// instance is broadcast-only (see platform_exchange), so there's no queue to protect.
+Rabbitmq.prototype._ensure_dead_letter_queue = async function () {
+  if (!this.config.queue_name || this._dead_letter_ready) {
+    return;
+  }
+  this._dlx_name = `${this.config.queue_name}.dlx`;
+  const dead_letter_queue_name = `${this.config.queue_name}.dlq`;
+  await this.ch.assertExchange(this._dlx_name, 'fanout', { durable: true });
+  await this.ch.assertQueue(dead_letter_queue_name, { durable: true });
+  await this.ch.bindQueue(dead_letter_queue_name, this._dlx_name, '');
+  this._dead_letter_ready = true;
+};
 
 Rabbitmq.prototype._ensure_delayed_exchange = async function () {
   if (this._delayed_ready) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@funnode/rabbitmq",
-  "version": "3.1.1",
+  "version": "3.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@funnode/rabbitmq",
-      "version": "3.1.1",
+      "version": "3.3.0",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funnode/rabbitmq",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "A rabbitmq wrapper with delayed message delivery support for funnode repositories",
   "main": "index.js",
   "scripts": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -30,6 +30,7 @@ describe('Rabbitmq', function () {
   let get;
   let ack;
   let sendToQueue;
+  let bindQueue;
   let closeConnection;
   let createChannel;
   let on;
@@ -59,6 +60,7 @@ describe('Rabbitmq', function () {
     get = sandbox.stub().resolves(msg);
     ack = sandbox.stub();
     sendToQueue = sandbox.stub().resolves();
+    bindQueue = sandbox.stub().resolves();
     closeConnection = sandbox.stub().resolves();
     on = sandbox.stub();
     createChannel = sandbox.stub().resolves({
@@ -71,7 +73,7 @@ describe('Rabbitmq', function () {
       ack,
       sendToQueue,
       publish: sandbox.stub(),
-      bindQueue: sandbox.stub().resolves(),
+      bindQueue,
       closeConnection,
     });
     connect = sandbox.stub().resolves({
@@ -214,6 +216,7 @@ describe('Rabbitmq', function () {
       get,
       ack,
       sendToQueue,
+      bindQueue,
       closeConnection
     });
     connect = sandbox.stub().resolves({
@@ -238,6 +241,7 @@ describe('Rabbitmq', function () {
       get,
       ack,
       sendToQueue,
+      bindQueue,
       closeConnection
     });
     connect = sandbox.stub().resolves({
@@ -254,6 +258,58 @@ describe('Rabbitmq', function () {
     await rabbitmq.connect(config);
     await rabbitmq.send(message);
     expect(sendToQueue).to.have.been.calledOnce;
+  });
+
+  describe('dead letter queue', function () {
+    it('declares a dead-letter exchange and queue, bound together, on connect', async function () {
+      await rabbitmq.connect(config);
+
+      expect(assertExchange).to.have.been.calledWith(`${config.queue_name}.dlx`, 'fanout', { durable: true });
+      expect(assertQueue).to.have.been.calledWith(`${config.queue_name}.dlq`, { durable: true });
+      expect(bindQueue).to.have.been.calledWith(`${config.queue_name}.dlq`, `${config.queue_name}.dlx`, '');
+    });
+
+    it('declares the primary queue with the dead-letter-exchange argument', async function () {
+      await rabbitmq.connect(config);
+      await rabbitmq.bind(consumer);
+
+      expect(assertQueue).to.have.been.calledWith(config.queue_name, {
+        durable: true,
+        arguments: { 'x-dead-letter-exchange': `${config.queue_name}.dlx` }
+      });
+    });
+
+    it('applies the same dead-letter arguments on get() and send() as on bind()', async function () {
+      await rabbitmq.connect(config);
+      await rabbitmq.get();
+      await rabbitmq.send(message);
+
+      const expected_options = {
+        durable: true,
+        arguments: { 'x-dead-letter-exchange': `${config.queue_name}.dlx` }
+      };
+      expect(assertQueue).to.have.been.calledWith(config.queue_name, expected_options);
+      expect(assertQueue.callCount).to.be.greaterThan(1);
+      assertQueue.getCalls()
+        .filter((call) => call.args[0] === config.queue_name)
+        .forEach((call) => expect(call.args[1]).to.eql(expected_options));
+    });
+
+    it('skips dead-letter setup for broadcast-only config without a queue_name', async function () {
+      const broadcast_config = { exchange_name: 'platform_exchange', exchange_type: 'fanout' };
+      await rabbitmq.connect(broadcast_config);
+
+      expect(assertExchange).to.not.have.been.calledWith(sinon.match(/\.dlx$/));
+      expect(assertQueue).to.not.have.been.calledWith(sinon.match(/\.dlq$/));
+    });
+
+    it('only declares the dead-letter exchange once across a reconnect', async function () {
+      await rabbitmq.connect(config);
+      const errorCallback = on.args[0][1];
+      await errorCallback({});
+
+      expect(assertExchange.withArgs(`${config.queue_name}.dlx`).callCount).to.eql(1);
+    });
   });
 
   describe('delayed delivery', function () {
@@ -280,8 +336,9 @@ describe('Rabbitmq', function () {
     });
 
     it('falls back to immediate send when delayed exchange fails', async function () {
-      // Make assertExchange fail for delayed exchange calls
-      assertExchange.onCall(1).rejects(new Error('Plugin not available'));
+      // assertExchange call order: 0 = main exchange, 1 = dead-letter exchange
+      // (both in connect()), 2 = delayed exchange (in sendDelayed). Make that one fail.
+      assertExchange.onCall(2).rejects(new Error('Plugin not available'));
       await rabbitmq.connect(config);
       await rabbitmq.sendDelayed(message, 2000);
 


### PR DESCRIPTION
Without this, a poison message that a consumer keeps nacking/erroring on just gets redelivered forever (crash-looping the pod on reconnect per finding #1) with no way to inspect or discard it. Every assertQueue call site (bind/get/send) now declares the same x-dead-letter-exchange argument so producer and consumer channels agree on queue arguments.

Note for rollout: existing to_games/to_messaging/to_bots queues on a live broker were declared without this argument, so the first assertQueue call against them post-deploy will hit a 406 PRECONDITION_FAILED (inequivalent arg) until those queues are deleted/recreated or migrated to a new name.